### PR TITLE
Initialize AdminOS Lab Django project

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+# Core Django settings
+DJANGO_SECRET_KEY=dev-insecure-secret-key
+DJANGO_DEBUG=True
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
+DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:8000
+
+# Database configuration (uncomment to use PostgreSQL)
+# DATABASE_URL=postgresql://adminos:password@localhost:5432/adminos_lab
+
+# Backup paths
+DJANGO_BACKUP_ROOT=backups
+DJANGO_BACKUP_DATABASE_DIR=backups/database
+DJANGO_BACKUP_MEDIA_DIR=backups/media
+
+# Rendering engines
+WEASYPRINT_TEMP_DIR=.tmp/weasyprint
+REPORTLAB_TEMP_DIR=.tmp/reportlab

--- a/adminos_lab/asgi.py
+++ b/adminos_lab/asgi.py
@@ -4,7 +4,7 @@ ASGI config for adminos_lab project.
 It exposes the ASGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
+https://docs.djangoproject.com/en/stable/howto/deployment/asgi/
 """
 
 import os

--- a/adminos_lab/asgi.py
+++ b/adminos_lab/asgi.py
@@ -1,0 +1,16 @@
+"""
+ASGI config for adminos_lab project.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
+"""
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "adminos_lab.settings")
+
+application = get_asgi_application()

--- a/adminos_lab/dev_settings.py
+++ b/adminos_lab/dev_settings.py
@@ -1,0 +1,23 @@
+"""Development-only Django settings for the AdminOS Lab project."""
+
+from __future__ import annotations
+
+from .settings import *  # noqa: F401,F403
+
+DEBUG = True
+ALLOWED_HOSTS = env.list(  # type: ignore[name-defined]
+    "DJANGO_ALLOWED_HOSTS",
+    default=["localhost", "127.0.0.1", "0.0.0.0"],
+)
+CSRF_TRUSTED_ORIGINS = env.list(  # type: ignore[name-defined]
+    "DJANGO_CSRF_TRUSTED_ORIGINS",
+    default=[f"http://{host}:8000" for host in ALLOWED_HOSTS if host != "127.0.0.1"],
+)
+
+DATABASES["default"] = env.db(  # type: ignore[name-defined]
+    "DATABASE_URL",
+    default=f"sqlite:///{(BASE_DIR / 'db.sqlite3').as_posix()}",
+)
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+INTERNAL_IPS = ["127.0.0.1"]

--- a/adminos_lab/settings.py
+++ b/adminos_lab/settings.py
@@ -1,0 +1,159 @@
+"""Django settings for the AdminOS Lab project.
+
+This module centralises configuration around environment variables so the
+application can move from local SQLite development to hosted PostgreSQL
+instances without code changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import environ
+
+# Build paths inside the project like this: BASE_DIR / "subdir".
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+def _project_path(value: Union[str, Path]) -> Path:
+    """Return an absolute path rooted at ``BASE_DIR`` when relative paths are provided."""
+
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = BASE_DIR / candidate
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Environment configuration
+# ---------------------------------------------------------------------------
+env = environ.Env(
+    DJANGO_DEBUG=(bool, False),
+    DJANGO_SECRET_KEY=(str, "change-me"),
+    DJANGO_ALLOWED_HOSTS=(list[str], ["localhost", "127.0.0.1"]),
+)
+
+_env_file = BASE_DIR / ".env"
+if _env_file.exists():
+    environ.Env.read_env(_env_file)
+
+SECRET_KEY = env("DJANGO_SECRET_KEY")
+DEBUG = env("DJANGO_DEBUG")
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
+
+# ---------------------------------------------------------------------------
+# Application definition
+# ---------------------------------------------------------------------------
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "adminos_lab.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "adminos_lab.wsgi.application"
+
+# ---------------------------------------------------------------------------
+# Database configuration
+# ---------------------------------------------------------------------------
+DATABASES = {
+    "default": env.db(
+        "DATABASE_URL",
+        default=f"sqlite:///{(BASE_DIR / 'db.sqlite3').as_posix()}",
+    )
+}
+DATABASES["default"].setdefault("ATOMIC_REQUESTS", True)
+
+if DATABASES["default"]["ENGINE"].endswith("postgresql"):
+    DATABASES["default"].setdefault("CONN_MAX_AGE", env.int("POSTGRES_CONN_MAX_AGE", default=60))
+    DATABASES["default"].setdefault(
+        "OPTIONS",
+        {"connect_timeout": env.int("POSTGRES_CONNECT_TIMEOUT", default=5)},
+    )
+
+# ---------------------------------------------------------------------------
+# Password validation
+# ---------------------------------------------------------------------------
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Internationalisation
+# ---------------------------------------------------------------------------
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+# ---------------------------------------------------------------------------
+# Static and media assets
+# ---------------------------------------------------------------------------
+STATIC_URL = "/static/"
+STATIC_ROOT = _project_path(env("DJANGO_STATIC_ROOT", default="staticfiles"))
+STATICFILES_DIRS = [_project_path("static")]
+
+MEDIA_URL = "/media/"
+MEDIA_ROOT = _project_path(env("DJANGO_MEDIA_ROOT", default="media"))
+
+BACKUP_ROOT = _project_path(env("DJANGO_BACKUP_ROOT", default="backups"))
+BACKUP_DATABASE_DIR = _project_path(
+    env("DJANGO_BACKUP_DATABASE_DIR", default=str(BACKUP_ROOT / "database"))
+)
+BACKUP_MEDIA_DIR = _project_path(
+    env("DJANGO_BACKUP_MEDIA_DIR", default=str(BACKUP_ROOT / "media"))
+)
+
+WEASYPRINT_BASEURL = env(
+    "WEASYPRINT_BASEURL",
+    default=str(_project_path("static")),
+)
+WEASYPRINT_TEMP_DIR = _project_path(env("WEASYPRINT_TEMP_DIR", default=".tmp/weasyprint"))
+REPORTLAB_TEMP_DIR = _project_path(env("REPORTLAB_TEMP_DIR", default=".tmp/reportlab"))
+
+# ---------------------------------------------------------------------------
+# Default primary key field type
+# ---------------------------------------------------------------------------
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/adminos_lab/urls.py
+++ b/adminos_lab/urls.py
@@ -2,7 +2,7 @@
 URL configuration for adminos_lab project.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.0/topics/http/urls/
+    https://docs.djangoproject.com/en/stable/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/adminos_lab/urls.py
+++ b/adminos_lab/urls.py
@@ -1,0 +1,23 @@
+"""
+URL configuration for adminos_lab project.
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/5.0/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+"""
+
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]

--- a/adminos_lab/wsgi.py
+++ b/adminos_lab/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for adminos_lab project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "adminos_lab.settings")
+
+application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "adminos_lab.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "adminos-lab"
+version = "0.1.0"
+description = "AdminOS Lab Django project"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "Django==5.2",
+    "django-environ>=0.11",
+    "psycopg[binary]>=3.1",
+    "weasyprint>=61.0",
+    "reportlab>=4.0",
+]
+
+[tool.django]
+settings-module = "adminos_lab.settings"


### PR DESCRIPTION
## Summary
- scaffold the AdminOS Lab Django project with manage.py and base package
- configure settings for environment-driven SQLite/PostgreSQL databases, backups, and document rendering
- add development overrides and a committed .env template alongside dependency metadata

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68ca890352148323b8a50ce5305a2dbc