### PR TITLE
Add MSDS documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,166 @@
-# msds
+# MSDS Platform
+
+MSDS (Municipal Services Data System) is a blueprint for a modular platform that centralizes
+service requests, inspections, and compliance data for municipal agencies. The project focuses on
+streamlining staff workflows, providing clear data lineage, and exposing reporting interfaces for
+internal auditors and external stakeholders.
+
+## Table of Contents
+- [Project Overview](#project-overview)
+- [System Goals](#system-goals)
+- [Setup Instructions](#setup-instructions)
+- [High-Level Architecture](#high-level-architecture)
+  - [Context Diagram](#context-diagram)
+  - [Logical Component Diagram](#logical-component-diagram)
+  - [Data Lifecycle](#data-lifecycle)
+- [Documentation Index](#documentation-index)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Project Overview
+MSDS aggregates structured and unstructured data from intake channels (web, phone, and field
+collections), enriches the information through validation pipelines, and stores the results in a
+centralized relational database. Core services include:
+
+- **Intake API** for capturing new service requests from public-facing portals.
+- **Operations Console** for municipal staff to triage, assign, and update requests.
+- **Field Toolkit** supporting inspectors with offline sync and geospatial overlays.
+- **Reporting & Audit Service** providing scheduled exports and ad hoc dashboards.
+
+## System Goals
+1. Provide a single source of truth for service request lifecycle data.
+2. Reduce manual data handling through automation, validation, and deduplication.
+3. Support compliance requirements with auditable change history and exportable records.
+4. Offer deployment flexibility across local developer machines, on-premise VPS, and hosted
+   environments such as Replit.
+
+## Setup Instructions
+Although this repository currently captures architecture and process documentation, the following
+steps prepare a development environment for the reference implementation described in the docs:
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/your-org/msds.git
+   cd msds
+   ```
+2. **Install system prerequisites**
+   - Python 3.11+
+   - Node.js 18+ (for the staff console front end)
+   - PostgreSQL 15+
+   - Redis 7+ (optional, used for task queues and caching)
+3. **Create and activate a Python virtual environment**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+4. **Install backend dependencies**
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+5. **Install front-end dependencies**
+   ```bash
+   cd frontend
+   npm install
+   cd ..
+   ```
+6. **Provision a local `.env` file** using the example provided in `config/.env.example`, then run
+   database migrations and seed data once application code is available.
+7. **Run the development stack** using the orchestration tool of your choice:
+   ```bash
+   docker compose up --build
+   ```
+
+Consult the dedicated deployment guides in `docs/deployment/` for environment-specific notes,
+including VPS hardening and Replit-specific configuration.
+
+## High-Level Architecture
+The MSDS platform follows a service-oriented architecture that separates intake, workflow
+orchestration, and reporting concerns. The diagrams below provide a high-level view.
+
+### Context Diagram
+```mermaid
+graph LR
+    CitizenPortal[Citizen Portal]
+    StaffUsers[Staff & Inspectors]
+    ExternalSystems[Partner Agencies]
+    ReportingConsumers[Auditors & Analysts]
+
+    CitizenPortal -->|Submit Requests| IntakeAPI[Intake API]
+    StaffUsers -->|Manage Cases| OpsConsole[Operations Console]
+    ExternalSystems -->|Data Exchange| IntegrationHub[Integration Hub]
+    ReportingConsumers -->|Exports & Dashboards| ReportingService[Reporting Service]
+
+    IntakeAPI --> CoreServices[MSDS Core Services]
+    OpsConsole --> CoreServices
+    IntegrationHub --> CoreServices
+    ReportingService --> CoreServices
+
+    CoreServices -->|Status Updates| CitizenPortal
+    CoreServices --> DataWarehouse[(Operational Data Store)]
+```
+
+### Logical Component Diagram
+```mermaid
+graph TD
+    subgraph Presentation
+        Portal[React Citizen Portal]
+        Console[Svelte Operations Console]
+    end
+
+    subgraph Services
+        API[FastAPI Intake Service]
+        Workflow[Temporal Workflow Orchestrator]
+        Reporting[Metabase Reporting Adapter]
+    end
+
+    subgraph Data
+        DB[(PostgreSQL)]
+        Cache[(Redis)]
+        Lake[(Object Storage)]
+    end
+
+    Portal --> API
+    Console --> API
+    API --> Workflow
+    Workflow --> DB
+    Workflow --> Cache
+    Reporting --> DB
+    Reporting --> Lake
+```
+
+### Data Lifecycle
+```mermaid
+sequenceDiagram
+    participant Citizen as Citizen Portal
+    participant Intake as Intake API
+    participant Workflow as Workflow Engine
+    participant Inspector as Field Toolkit
+    participant DB as PostgreSQL
+    participant Audit as Audit Service
+
+    Citizen->>Intake: Submit service request
+    Intake->>Workflow: Validate & enqueue job
+    Workflow->>DB: Persist request & assignments
+    Inspector->>Workflow: Sync field updates
+    Workflow->>DB: Append change history
+    Audit-->>DB: Fetch immutable ledger view
+    Audit-->>Citizen: Provide status export
+```
+
+## Documentation Index
+| Topic | Location |
+|-------|----------|
+| Blueprint & delivery roadmap | [`docs/blueprint-roadmap.md`](docs/blueprint-roadmap.md) |
+| Acceptance test catalogue | [`docs/acceptance-tests.md`](docs/acceptance-tests.md) |
+| MSDS data field mapping | [`docs/msds-field-mapping.md`](docs/msds-field-mapping.md) |
+| Deployment guides (local, VPS, Replit) | [`docs/deployment/`](docs/deployment/) |
+| Usage examples & operational runbooks | [`docs/usage-examples.md`](docs/usage-examples.md) |
+
+## Contributing
+1. Fork the repository and create feature branches from `main`.
+2. Write clear commit messages and keep pull requests scoped.
+3. Update documentation and tests alongside any code changes.
+4. Run acceptance tests documented in `docs/acceptance-tests.md` before opening a PR.
+
+## License
+This project is released under the [MIT License](LICENSE).

--- a/docs/acceptance-tests.md
+++ b/docs/acceptance-tests.md
@@ -1,0 +1,70 @@
+# Acceptance Test Catalogue
+
+This catalogue enumerates high-level acceptance criteria for the MSDS platform. Each scenario maps
+to automated regression suites and manual verification activities. IDs follow the format
+`<Domain>-<Number>` for traceability with the roadmap and Jira epics.
+
+## Legend
+- **Type:** `AUTO` (automated), `MANUAL`, or `HYBRID`.
+- **Priority:** `P0` (must pass before release), `P1`, `P2`.
+- **Owner:** Responsible team or role.
+
+## Intake & Validation
+| ID | Title | Type | Priority | Owner | Description |
+|----|-------|------|----------|-------|-------------|
+| IN-001 | Citizen request submission | AUTO | P0 | Platform | Submit request with mandatory fields; expect HTTP 201 and persisted record. |
+| IN-002 | Duplicate request suppression | AUTO | P1 | Platform | Submit identical payload twice; expect deduplication with reference to original case. |
+| IN-003 | Attachment virus scanning | HYBRID | P0 | Security | Upload file with EICAR signature; ensure quarantine workflow triggers and citizen notified. |
+| IN-004 | SLA classification | AUTO | P0 | Platform | Intake API assigns SLA clock based on category configuration. |
+| IN-005 | Multi-channel ingestion | MANUAL | P1 | Operations | Validate phone hotline transcription and email ingestion create standardized requests. |
+
+## Operations Console
+| ID | Title | Type | Priority | Owner | Description |
+|----|-------|------|----------|-------|-------------|
+| OP-001 | Role-based access control | AUTO | P0 | IAM | Staff with "Supervisor" role can reassign cases; field inspectors cannot. |
+| OP-002 | Bulk status updates | AUTO | P1 | Platform | Update 50 cases simultaneously; verify change history contains entries for each case. |
+| OP-003 | Offline sync reconciliation | MANUAL | P0 | Field Ops | Inspectors update cases offline; sync resolves conflicts using last-write-wins with audit trail. |
+| OP-004 | SLA breach alerts | AUTO | P0 | Platform | Cases nearing SLA deadlines trigger notifications and appear in dashboard filters. |
+| OP-005 | Accessibility conformance | MANUAL | P0 | Design | Console screens satisfy WCAG 2.1 AA using automated axe scan plus manual review. |
+
+## Reporting & Audit
+| ID | Title | Type | Priority | Owner | Description |
+|----|-------|------|----------|-------|-------------|
+| RA-001 | Nightly audit export | AUTO | P0 | Data | Export job produces encrypted CSV, uploads to S3, and logs checksum. |
+| RA-002 | Immutable ledger verification | AUTO | P0 | Data | Modifying records creates append-only entries; direct updates blocked by database triggers. |
+| RA-003 | Data retention policy | HYBRID | P1 | Legal | Records older than retention window archived; purge job emits compliance report. |
+| RA-004 | Dashboard accuracy | MANUAL | P1 | Analytics | Compare key metrics (volume, SLA compliance) between dashboard and warehouse queries. |
+| RA-005 | Public transparency portal | AUTO | P2 | Platform | Sanitized dataset publishes to open-data endpoint with personal data removed. |
+
+## Integration Layer
+| ID | Title | Type | Priority | Owner | Description |
+|----|-------|------|----------|-------|-------------|
+| INTEGR-001 | Partner webhook delivery | AUTO | P0 | Integrations | Simulate webhook event; partner receives payload with signed headers within 3s. |
+| INTEGR-002 | SFTP batch import | HYBRID | P1 | Integrations | Nightly batch ingested; failures alert via PagerDuty. |
+| INTEGR-003 | API rate limiting | AUTO | P0 | Security | Exceed rate limits; expect 429 responses and no data loss. |
+| INTEGR-004 | Schema evolution | MANUAL | P2 | Data | Rolling deployment preserves backwards compatibility with versioned APIs. |
+
+## Non-Functional
+| ID | Title | Type | Priority | Owner | Description |
+|----|-------|------|----------|-------|-------------|
+| NF-001 | Load test | AUTO | P0 | Performance | Sustained 500 RPS on intake API with <1% error rate. |
+| NF-002 | Disaster recovery | MANUAL | P0 | SRE | Trigger infrastructure failover; environment recovers within 60 minutes using documented runbook. |
+| NF-003 | Observability | AUTO | P1 | SRE | Service emits traces, structured logs, and metrics with 95% coverage of key paths. |
+| NF-004 | Security scanning | AUTO | P0 | Security | CI pipeline runs SAST, dependency scanning, container scanning with zero critical findings. |
+| NF-005 | Privacy impact assessment | MANUAL | P1 | Legal | Review data handling flows for compliance with local privacy regulations. |
+
+## Traceability Matrix
+| Roadmap Phase | Acceptance Tests |
+|---------------|------------------|
+| Phase 0 – Foundations | NF-002, NF-004, NF-005 |
+| Phase 1 – Intake & Core Data | IN-001, IN-002, IN-004, NF-001 |
+| Phase 2 – Staff Operations | OP-001, OP-002, OP-004, NF-003 |
+| Phase 3 – Field Toolkit | OP-003, NF-002 |
+| Phase 4 – Reporting & Audit | RA-001, RA-002, RA-003, RA-004 |
+| Phase 5 – Optimization | INTEGR-001, INTEGR-002, INTEGR-003, NF-001 |
+
+## Execution Cadence
+- **Continuous Integration:** All `AUTO` tests run per pull request.
+- **Nightly Regression:** Full automated suite plus targeted hybrid smoke tests.
+- **Pre-Release:** Manual verification of `P0` and `P1` scenarios with sign-off from owning teams.
+- **Post-Release Monitoring:** 48-hour watch window with live dashboards and PagerDuty coverage.

--- a/docs/blueprint-roadmap.md
+++ b/docs/blueprint-roadmap.md
@@ -1,0 +1,66 @@
+# MSDS Blueprint & Delivery Roadmap
+
+## Vision
+Create a resilient municipal services data platform that unifies intake, workflow coordination,
+field operations, and reporting across agencies. MSDS emphasizes modularity, compliance, and
+operational transparency from day one.
+
+## Guiding Principles
+- **Human-centered design:** Build tools that match the daily rituals of municipal staff and field
+  inspectors.
+- **Data trust:** Maintain lineage, validation, and audit trails to support compliance.
+- **Adaptable deployments:** Offer configuration-driven deployments for on-premise, cloud, and
+  managed environments such as Replit.
+- **Incremental delivery:** Ship thin slices of functionality that unlock value quickly while
+  reducing project risk.
+
+## Architecture Blueprint
+1. **Presentation Layer**
+   - React-based citizen portal for public submissions and status checks.
+   - Svelte-based operations console for internal staff triage and oversight.
+2. **Service Layer**
+   - FastAPI intake service with schema validation, deduplication, and queuing.
+   - Temporal workflow orchestrator driving case progression and SLA timers.
+   - Reporting adapters (Metabase, dbt models) that expose curated datasets.
+3. **Data Layer**
+   - PostgreSQL operational store with immutable ledger tables for auditability.
+   - Redis cache for accelerating queue lookups and session data.
+   - Object storage for attachments, geospatial overlays, and export packages.
+4. **Integration Layer**
+   - Event-driven connectors (webhooks, SFTP, flat-file) to exchange data with partner systems.
+   - API gateway with rate limiting and zero-trust posture for external consumers.
+
+## Delivery Roadmap
+| Phase | Timeline | Milestones | Success Criteria |
+|-------|----------|------------|------------------|
+| **Phase 0 – Foundations** | Weeks 0-2 | Governance kickoff, data inventory, initial schema draft | Stakeholders aligned on scope and success metrics |
+| **Phase 1 – Intake & Core Data** | Weeks 3-8 | Intake API, citizen portal MVP, PostgreSQL schema, ETL loaders | 80% of legacy requests migrated, new intake functioning |
+| **Phase 2 – Staff Operations** | Weeks 9-14 | Operations console, role-based access control, workflow automation | Average triage time reduced by 40%, SLA tracking live |
+| **Phase 3 – Field Toolkit** | Weeks 15-20 | Mobile-first field interface, offline sync, geospatial overlays | 90% sync success rate, inspectors adopt digital updates |
+| **Phase 4 – Reporting & Audit** | Weeks 21-24 | Reporting dashboards, audit exports, compliance alerts | Auditors access monthly exports without IT assistance |
+| **Phase 5 – Optimization** | Weeks 25-30 | Performance tuning, scale tests, backlog grooming | System supports 5x baseline volume with <2s response time |
+
+## Risk Register (Top 5)
+1. **Data Quality Gaps** – Mitigation: embed validation rules in intake flows and create QA
+   dashboards.
+2. **Change Management Resistance** – Mitigation: schedule staff ride-alongs and training loops in
+   each phase.
+3. **Integration Complexity** – Mitigation: prioritize partner APIs with pilot agencies and provide
+   sandbox credentials early.
+4. **Security & Compliance** – Mitigation: adopt CIS benchmarks, implement automated compliance
+   scanning, and require least-privilege IAM roles.
+5. **Resource Constraints** – Mitigation: cross-train teams, maintain prioritized backlog, and use
+   feature flags for staged releases.
+
+## KPIs & Reporting Cadence
+- **Service Request Throughput:** Number of requests processed per week.
+- **Resolution SLA Adherence:** Percentage of cases closed within defined SLA windows.
+- **Data Completeness:** Percentage of required MSDS fields populated across lifecycle stages.
+- **Export Reliability:** Success rate of scheduled audit exports and backup jobs.
+- **User Satisfaction:** Quarterly survey and qualitative feedback loops with staff and citizens.
+
+## Next Steps
+- Finalize acceptance criteria (see `docs/acceptance-tests.md`).
+- Complete field mapping exercises with departmental SMEs.
+- Stand up development infrastructure following the deployment guides.
+- Schedule fortnightly roadmap reviews with product, engineering, and operations leads.

--- a/docs/deployment/local.md
+++ b/docs/deployment/local.md
@@ -1,0 +1,90 @@
+# Local Development Deployment Guide
+
+This guide walks through running the MSDS reference stack on a developer workstation. It assumes a
+Unix-like environment (macOS, Linux, or WSL2) with administrative privileges.
+
+## Prerequisites
+- Python 3.11+
+- Node.js 18+
+- Docker Desktop or Docker Engine with Compose v2
+- PostgreSQL 15 (local installation or Docker container)
+- Redis 7 (optional, for background job support)
+
+## 1. Clone and Bootstrap
+```bash
+git clone https://github.com/your-org/msds.git
+cd msds
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+cd frontend && npm install && cd ..
+```
+
+## 2. Configure Environment Variables
+1. Copy the example environment file:
+   ```bash
+   cp config/.env.example config/.env
+   ```
+2. Edit `config/.env` and set:
+   - `DATABASE_URL=postgresql://msds:msds@localhost:5432/msds`
+   - `REDIS_URL=redis://localhost:6379/0`
+   - `SECRET_KEY`, `JWT_AUDIENCE`, `JWT_ISSUER`
+   - API client credentials for third-party integrations (optional during local dev).
+
+## 3. Start Dependencies
+You may run services via Docker or host-provided packages.
+
+### Option A: Docker Compose
+```bash
+docker compose -f docker-compose.local.yml up -d postgres redis
+```
+
+### Option B: Native Services
+- Start PostgreSQL and create database:
+  ```bash
+  createdb msds
+  createuser msds --pwprompt
+  psql -c "GRANT ALL PRIVILEGES ON DATABASE msds TO msds;"
+  ```
+- (Optional) Start Redis locally: `redis-server`
+
+## 4. Apply Database Migrations
+```bash
+alembic upgrade head
+python backend/scripts/seed_demo_data.py
+```
+
+## 5. Launch Application Services
+```bash
+# Terminal 1 - Backend API
+uvicorn backend.app:app --reload --port 8000
+
+# Terminal 2 - Workflow worker
+python backend/workers/start_workers.py
+
+# Terminal 3 - Frontend dev server
+cd frontend
+npm run dev -- --open
+```
+
+## 6. Access the Application
+- Backend API: http://localhost:8000/docs (Swagger UI)
+- Operations Console: http://localhost:5173
+- Temporal UI (if enabled): http://localhost:7233
+
+## 7. Run Tests
+```bash
+pytest
+npm test
+```
+
+## 8. Troubleshooting
+- **Port conflicts:** Adjust ports in `docker-compose.local.yml` and `.env`.
+- **SSL certificates:** Local dev uses HTTP; disable strict transport security in browsers when
+  testing web features.
+- **Migrations failing:** Ensure PostgreSQL user has privileges; check Alembic versions table.
+
+## 9. Developer Productivity Tips
+- Enable hot-reload for the backend via `uvicorn --reload`.
+- Use VS Code Dev Containers or JetBrains Gateway for consistent toolchains.
+- Seed demo data frequently to exercise dashboards and audit exports.

--- a/docs/deployment/replit.md
+++ b/docs/deployment/replit.md
@@ -1,0 +1,91 @@
+# Replit Deployment Guide
+
+This guide explains how to launch a managed demo of MSDS on [Replit](https://replit.com/). Replit is
+well-suited for product demos, training sessions, and lightweight pilots.
+
+## 1. Prepare the Repository
+1. Ensure the latest code is pushed to GitHub on the `main` branch.
+2. Include the following files for Replit compatibility:
+   - `.replit` – sets the run command.
+   - `replit.nix` – defines the Nix environment (Python, Node.js, PostgreSQL client).
+   - `docker-compose.replit.yml` (optional) – orchestrates services in the Replit workspace.
+
+## 2. Create the Repl
+1. Visit Replit and click **Create Repl**.
+2. Choose **Import from GitHub** and paste the repository URL (`https://github.com/your-org/msds`).
+3. Select the `main` branch and import.
+
+## 3. Configure Environment Variables
+Open the **Secrets** panel (lock icon) and add:
+- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/msds`
+- `REDIS_URL=redis://localhost:6379/0`
+- `SECRET_KEY` (generate via `python -c "import secrets; print(secrets.token_urlsafe(32))"`)
+- `JWT_AUDIENCE`, `JWT_ISSUER`
+- Optional third-party API keys for maps, email, and SMS.
+
+## 4. Install Dependencies
+Replit automatically executes `poetry install` or `pip install -r requirements.txt` based on project
+files. For the MSDS blueprint:
+```bash
+pip install -r backend/requirements.txt
+cd frontend && npm install && npm run build && cd ..
+```
+
+Ensure `replit.nix` includes:
+```nix
+{ pkgs }: {
+  deps = [
+    pkgs.python311
+    pkgs.python311Packages.pip
+    pkgs.nodejs-18_x
+    pkgs.postgresql
+    pkgs.redis
+  ];
+}
+```
+
+## 5. Launch Services
+Update `.replit` with the run command:
+```
+run = "bash start-replit.sh"
+```
+
+Create `start-replit.sh` in the repository (tracked) with:
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start PostgreSQL & Redis inside Replit
+pg_ctl -D $REPL_HOME/postgres -l $REPL_HOME/postgres/logfile start || true
+redis-server --daemonize yes
+
+# Apply migrations and seed minimal data
+source .venv/bin/activate
+alembic upgrade head
+python backend/scripts/seed_demo_data.py
+
+# Run backend and frontend concurrently
+uvicorn backend.app:app --host 0.0.0.0 --port 8000 &
+cd frontend && npm run dev -- --host --port 3000
+```
+
+Ensure the script is executable: `chmod +x start-replit.sh`.
+
+## 6. Configure Webview
+In the Replit **Shell**, expose ports:
+- Backend: `8000` (set as hidden)
+- Frontend: `3000` (set as primary webview)
+
+## 7. Persistent Storage Considerations
+- Replit provides ephemeral storage; schedule export jobs to S3 or Google Drive (see
+  `docs/usage-examples.md#backup-procedures`).
+- Use lightweight datasets and limit attachment sizes for demos.
+
+## 8. Collaboration Features
+- Enable **Multiplayer** to collaborate on debugging or training.
+- Use the built-in **Version Control** tab to commit documentation updates directly from Replit.
+
+## 9. Maintenance & Cost Controls
+- Stop the Repl when not in use to avoid exceeding Replit usage quotas.
+- Configure autosleep timers in `.replit` if the workload allows.
+- Monitor the Replit console for CPU and memory warnings; adjust service settings accordingly.

--- a/docs/deployment/replit.md
+++ b/docs/deployment/replit.md
@@ -56,7 +56,11 @@ Create `start-replit.sh` in the repository (tracked) with:
 set -euo pipefail
 
 # Start PostgreSQL & Redis inside Replit
-pg_ctl -D $REPL_HOME/postgres -l $REPL_HOME/postgres/logfile start || true
+if pg_ctl -D "$REPL_HOME/postgres" status > /dev/null 2>&1; then
+  echo "PostgreSQL is already running."
+else
+  pg_ctl -D "$REPL_HOME/postgres" -l "$REPL_HOME/postgres/logfile" start
+fi
 redis-server --daemonize yes
 
 # Apply migrations and seed minimal data

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -1,0 +1,152 @@
+# VPS Deployment Guide
+
+This guide describes deploying MSDS to a self-managed virtual private server (VPS) such as Digital
+Ocean, Linode, or AWS Lightsail. It assumes Ubuntu 22.04 LTS, root SSH access, and familiarity with
+basic Linux administration.
+
+## 1. Provision Infrastructure
+- **Server size:** 4 vCPU, 8 GB RAM, 80 GB SSD (adjust for production load).
+- **Networking:** Enable static IP, configure DNS `msds.example.gov`.
+- **Security groups/firewall:** Allow inbound ports 22 (SSH), 80 (HTTP), 443 (HTTPS).
+
+## 2. Harden the Host
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y fail2ban ufw unattended-upgrades
+sudo adduser msds --disabled-password
+sudo usermod -aG sudo msds
+sudo cp ~/.ssh/authorized_keys /home/msds/.ssh/authorized_keys
+sudo chown -R msds:msds /home/msds/.ssh
+sudo chmod 700 /home/msds/.ssh && sudo chmod 600 /home/msds/.ssh/authorized_keys
+sudo ufw allow OpenSSH
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+```
+
+## 3. Install Runtime Dependencies
+```bash
+sudo apt install -y nginx certbot python3-certbot-nginx docker.io docker-compose-plugin postgresql redis-server
+sudo systemctl enable docker postgresql redis-server
+```
+
+Create PostgreSQL roles and database:
+```bash
+sudo -u postgres createuser msds --pwprompt
+sudo -u postgres createdb msds -O msds
+```
+
+## 4. Fetch Application Code
+```bash
+sudo mkdir -p /opt/msds
+sudo chown -R msds:msds /opt/msds
+sudo -i -u msds bash <<'SCRIPT'
+cd /opt/msds
+git clone https://github.com/your-org/msds.git .
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+cd frontend && npm install && npm run build && cd ..
+npm install -g pm2
+SCRIPT
+```
+
+## 5. Configure Environment
+Create `/opt/msds/config/.env` with production secrets:
+```
+DATABASE_URL=postgresql://msds:<PASSWORD>@127.0.0.1:5432/msds
+REDIS_URL=redis://127.0.0.1:6379/0
+SECRET_KEY=<generate>
+JWT_ISSUER=https://msds.example.gov
+JWT_AUDIENCE=msds-users
+FILE_STORAGE_BUCKET=s3://msds-prod-attachments
+```
+
+Ensure `config/settings.prod.yaml` reflects production toggles (caching, logging, CDN endpoints).
+
+## 6. Database Migrations & Seed
+```bash
+sudo -i -u msds bash <<'SCRIPT'
+cd /opt/msds
+source .venv/bin/activate
+alembic upgrade head
+python backend/scripts/seed_reference_data.py
+SCRIPT
+```
+
+## 7. Process Management
+Use `pm2` (Node) and `systemd` (Python workers) to manage services.
+
+### Backend API (`systemd`)
+Create `/etc/systemd/system/msds-api.service`:
+```
+[Unit]
+Description=MSDS API
+After=network.target
+
+[Service]
+User=msds
+WorkingDirectory=/opt/msds
+Environment="ENV_FILE=/opt/msds/config/.env"
+ExecStart=/opt/msds/.venv/bin/uvicorn backend.app:app --host 0.0.0.0 --port 8000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload and start:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now msds-api
+```
+
+### Workflow Worker (`systemd`)
+Repeat with `/etc/systemd/system/msds-worker.service` invoking
+`/opt/msds/.venv/bin/python backend/workers/start_workers.py`.
+
+### Frontend (`pm2`)
+```bash
+sudo -i -u msds pm2 serve frontend/dist 4173 --name msds-frontend --spa
+sudo -i -u msds pm2 save
+sudo pm2 startup systemd -u msds --hp /home/msds
+```
+
+## 8. Reverse Proxy & TLS
+Configure Nginx `/etc/nginx/sites-available/msds`:
+```
+server {
+    listen 80;
+    server_name msds.example.gov;
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:4173/;
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+Enable and secure:
+```bash
+sudo ln -s /etc/nginx/sites-available/msds /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+sudo certbot --nginx -d msds.example.gov
+```
+
+## 9. Monitoring & Backups
+- Install Prometheus Node Exporter and configure scraping.
+- Forward logs to centralized syslog (e.g., Graylog).
+- Schedule nightly PostgreSQL dumps via `pg_dump` to encrypted object storage (see
+  `docs/usage-examples.md#backup-procedures`).
+
+## 10. Disaster Recovery Drills
+- Test restoring PostgreSQL dumps to staging.
+- Validate Redis persistence or use `redis-cli --rdb` for snapshots.
+- Simulate failover by rotating DNS to standby VPS; ensure automation scripts run cleanly.

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -13,7 +13,7 @@ basic Linux administration.
 ```bash
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y fail2ban ufw unattended-upgrades
-sudo adduser msds --disabled-password
+sudo adduser msds --disabled-password --disabled-login --system
 sudo usermod -aG sudo msds
 sudo cp ~/.ssh/authorized_keys /home/msds/.ssh/authorized_keys
 sudo chown -R msds:msds /home/msds/.ssh

--- a/docs/msds-field-mapping.md
+++ b/docs/msds-field-mapping.md
@@ -1,0 +1,85 @@
+# MSDS Data Field Mapping
+
+This document defines canonical field names, data types, and lineage for the MSDS operational data
+store. Use these mappings when designing APIs, database schemas, ETL processes, and reporting
+artifacts.
+
+## Core Entities
+### Service Request (`service_requests`)
+| Field | Type | Source | Required | Description |
+|-------|------|--------|----------|-------------|
+| `request_id` | UUID | Generated | Yes | Primary identifier for the request; immutable. |
+| `external_reference` | String | Intake | No | ID supplied by partner agencies or legacy systems. |
+| `channel` | Enum (`portal`, `phone`, `email`, `field`, `api`) | Intake | Yes | Submission channel. |
+| `category` | String | Intake | Yes | Service category selected by citizen or assigned by staff. |
+| `subcategory` | String | Intake | No | Optional refinement for analytics. |
+| `status` | Enum (`new`, `triaged`, `assigned`, `in_progress`, `waiting_external`, `resolved`, `closed`) | Workflow | Yes | Current lifecycle state. |
+| `priority` | Enum (`low`, `medium`, `high`, `critical`) | Workflow | Yes | Derived from SLA rules. |
+| `sla_due_at` | Timestamp | Workflow | No | Deadline for SLA compliance. |
+| `description` | Text | Intake | Yes | Citizen-provided narrative. |
+| `location_lat` | Decimal(9,6) | Geocoder | No | Latitude of service request. |
+| `location_lng` | Decimal(9,6) | Geocoder | No | Longitude of service request. |
+| `civic_address_id` | UUID | GIS | No | Foreign key to canonical address registry. |
+| `created_at` | Timestamp | System | Yes | UTC timestamp when record created. |
+| `updated_at` | Timestamp | System | Yes | Last modification time (immutable ledger stores change history). |
+
+### Person (`persons`)
+| Field | Type | Source | Required | Description |
+|-------|------|--------|----------|-------------|
+| `person_id` | UUID | Generated | Yes | Primary identifier. |
+| `role` | Enum (`citizen`, `staff`, `inspector`, `admin`, `partner`) | Intake/HR | Yes | Role classification. |
+| `first_name` | String | Intake/HR | Yes | Given name. |
+| `last_name` | String | Intake/HR | Yes | Family name. |
+| `email` | String | Intake/HR | No | Contact email; hashed for citizens per privacy rules. |
+| `phone` | String | Intake/HR | No | E.164 formatted phone number. |
+| `department` | String | HR | No | Department for staff/inspectors. |
+| `created_at` | Timestamp | System | Yes | Record creation timestamp. |
+| `updated_at` | Timestamp | System | Yes | Last update timestamp. |
+
+### Assignment (`assignments`)
+| Field | Type | Source | Required | Description |
+|-------|------|--------|----------|-------------|
+| `assignment_id` | UUID | Generated | Yes | Primary identifier. |
+| `request_id` | UUID | Workflow | Yes | Foreign key to service request. |
+| `assignee_id` | UUID | Workflow | Yes | Person responsible (staff or inspector). |
+| `assigned_at` | Timestamp | Workflow | Yes | Time assignment created. |
+| `due_at` | Timestamp | Workflow | No | Optional due date for the assignment. |
+| `status` | Enum (`assigned`, `accepted`, `in_progress`, `completed`, `returned`) | Workflow | Yes | Assignment lifecycle state. |
+| `notes` | Text | Workflow | No | Internal notes. |
+
+### Audit Event (`audit_events`)
+| Field | Type | Source | Required | Description |
+|-------|------|--------|----------|-------------|
+| `event_id` | UUID | Generated | Yes | Primary identifier. |
+| `entity_type` | Enum (`service_request`, `assignment`, `person`, `attachment`) | System | Yes | Entity impacted. |
+| `entity_id` | UUID | System | Yes | Identifier of impacted entity. |
+| `action` | Enum (`create`, `update`, `delete`, `status_change`, `export`) | System | Yes | Action performed. |
+| `actor_id` | UUID | System | Yes | Person or service account responsible. |
+| `payload` | JSONB | System | Yes | Serialized diff or metadata. |
+| `ip_address` | Inet | System | No | Source IP for security audits. |
+| `created_at` | Timestamp | System | Yes | Event timestamp. |
+
+## Derived & Analytical Fields
+| Field | Type | Calculation | Notes |
+|-------|------|-------------|-------|
+| `response_time_minutes` | Integer | Difference between first staff assignment and request creation | Used for SLA reporting. |
+| `resolution_time_minutes` | Integer | Difference between `status=resolved` timestamp and request creation | Displayed in dashboards. |
+| `reopen_count` | Integer | Number of times status transitions from `closed`/`resolved` back to active states | Helps flag recurring issues. |
+| `geo_bucket` | String | Spatial join of lat/long to hex bin | Supports geospatial heatmaps. |
+| `sentiment_score` | Decimal | NLP score from citizen narrative | Optional feature, stored with provenance. |
+
+## Data Lineage Notes
+- **Intake API** is the system of record for `service_requests` and `attachments` at creation time.
+- **Workflow Engine** appends to `assignments`, updates `status`, and triggers audit events.
+- **Field Toolkit** synchronizes offline updates through the Workflow API; conflicts resolved using
+  deterministic merge rules documented in `docs/acceptance-tests.md` (OP-003).
+- **Reporting Warehouse** (dbt/Metabase) consumes the operational store via nightly snapshot and
+  publishes curated datasets for dashboards and exports.
+
+## Governance & Stewardship
+- Data steward: **Operations Analytics Lead**.
+- Schema authority: **Platform Engineering**.
+- Change management: propose updates via data governance board; capture diffs in migration scripts
+  and update this mapping.
+- Privacy impact: personally identifiable information (PII) stored in hashed/encrypted form; refer to
+  privacy assessment checklist in `docs/acceptance-tests.md` (NF-005).

--- a/docs/msds-field-mapping.md
+++ b/docs/msds-field-mapping.md
@@ -30,7 +30,7 @@ artifacts.
 | `role` | Enum (`citizen`, `staff`, `inspector`, `admin`, `partner`) | Intake/HR | Yes | Role classification. |
 | `first_name` | String | Intake/HR | Yes | Given name. |
 | `last_name` | String | Intake/HR | Yes | Family name. |
-| `email` | String | Intake/HR | No | Contact email; hashed for citizens per privacy rules. |
+| `email` | String | Intake/HR | No | Contact email; for citizens, hashed using SHA-256 with a per-record salt per privacy rules. |
 | `phone` | String | Intake/HR | No | E.164 formatted phone number. |
 | `department` | String | HR | No | Department for staff/inspectors. |
 | `created_at` | Timestamp | System | Yes | Record creation timestamp. |

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,0 +1,118 @@
+# Usage Examples & Operational Runbooks
+
+This document provides guided walkthroughs for common MSDS workflows across staff, administrators,
+and compliance teams. Scripts and automation snippets referenced here should be version-controlled in
+this repository alongside application code.
+
+## Table of Contents
+- [Staff Workflows](#staff-workflows)
+  - [Triage & Assignment](#triage--assignment)
+  - [Field Inspection Sync](#field-inspection-sync)
+  - [Escalating SLA Breaches](#escalating-sla-breaches)
+- [Administrator Workflows](#administrator-workflows)
+  - [User Provisioning](#user-provisioning)
+  - [Configuration Changes](#configuration-changes)
+- [Backup Procedures](#backup-procedures)
+  - [Operational Database Backup](#operational-database-backup)
+  - [Object Storage Snapshot](#object-storage-snapshot)
+  - [Disaster Recovery Verification](#disaster-recovery-verification)
+- [Audit Export Processes](#audit-export-processes)
+  - [Scheduled Nightly Export](#scheduled-nightly-export)
+  - [Ad Hoc Case Packet](#ad-hoc-case-packet)
+  - [Transparency Portal Publication](#transparency-portal-publication)
+
+## Staff Workflows
+### Triage & Assignment
+1. Log in to the Operations Console and open the **New Requests** queue.
+2. Review each request summary, attachments, and map location.
+3. Click **Validate** to confirm channel metadata; corrections create `audit_events` with `action=update`.
+4. Assign to a staff unit:
+   - Click **Assign** → select `Department` and `Assignee`.
+   - Set priority and SLA override if needed.
+   - Optionally attach standard response templates.
+5. Outcome: `assignments` table records a new row; request `status` transitions to `assigned`.
+6. Acceptance tests: refer to `OP-001`, `OP-002` in `docs/acceptance-tests.md`.
+
+### Field Inspection Sync
+1. Inspector opens the Field Toolkit mobile app and downloads their queue before going offline.
+2. During inspection, updates findings, photos, and status changes.
+3. Upon reconnecting, app syncs with Workflow API. Conflicts resolved per last-write-wins; conflicting
+   attributes flagged for supervisor review.
+4. Supervisor reviews sync report within Operations Console → **Sync Reconciliation** tab.
+5. Outcome: offline events produce `audit_events` with actor = inspector; case timeline shows merged
+   history.
+6. Monitor using dashboard widget **Offline Sync Success Rate**.
+
+### Escalating SLA Breaches
+1. From Operations Console, open **SLA Watchlist** filter (requests with `sla_due_at` < 24 hours).
+2. Trigger **Escalate** action to notify supervisors via email/SMS and add `priority=critical`.
+3. System generates Temporal workflow signal to expedite scheduling.
+4. If unresolved past SLA, automatic status change to `waiting_external` or `in_progress` with reason.
+5. Document manual follow-up notes in request timeline for audit compliance.
+
+## Administrator Workflows
+### User Provisioning
+1. Navigate to **Admin → User Management**.
+2. Click **Invite User** and supply name, email, department, and role (`staff`, `inspector`, `admin`).
+3. System sends invitation email with activation link; upon acceptance, user appears in `persons` table.
+4. For API-only accounts, generate service tokens under **Admin → API Clients**. Store secrets in vault.
+5. Deactivate accounts via **Suspend** to preserve history while revoking access.
+
+### Configuration Changes
+1. Access **Admin → Configuration → Taxonomy** to adjust service categories.
+2. Changes trigger versioned configuration stored in `config/service-taxonomy.yaml`.
+3. Platform automatically redeploys workflow rules using CI pipeline; review pipeline status before
+   confirming release.
+4. Document changes in change-log channel and update training materials as needed.
+
+## Backup Procedures
+### Operational Database Backup
+- Nightly job executed via `cron` on VPS or GitHub Actions workflow:
+  ```bash
+  pg_dump --format=custom --file=/backups/msds-$(date +%Y%m%d).dump $DATABASE_URL
+  aws s3 cp /backups/msds-$(date +%Y%m%d).dump s3://msds-backups/ --sse AES256
+  ```
+- Retain 30 days of nightly backups, 12 monthly archives.
+- Verify checksums using `sha256sum` and store results in the backup log table `backup_runs`.
+
+### Object Storage Snapshot
+- Use lifecycle policies to transition attachments to Glacier after 90 days.
+- Weekly job exports manifest of new/updated objects:
+  ```bash
+  aws s3 ls s3://msds-attachments --recursive --human-readable \
+    --summarize > reports/attachments-$(date +%Y%m%d).txt
+  ```
+- Commit manifests to the repository for traceability when feasible (mask PII before commit).
+
+### Disaster Recovery Verification
+1. Restore latest database dump into staging environment.
+2. Rehydrate object storage manifest to ensure references remain valid.
+3. Run smoke tests (`IN-001`, `OP-001`, `RA-001`) to confirm functional parity.
+4. Document results in `docs/dr-runbooks/` (create dated subfolder per drill).
+
+## Audit Export Processes
+### Scheduled Nightly Export
+1. Temporal workflow `audit_export_nightly` triggers at 02:00 local time.
+2. Workflow executes dbt models `audit_case_snapshot` and `audit_assignment_snapshot`.
+3. Export results zipped, encrypted (AES-256), and uploaded to S3 `s3://msds-audit-exports/YYYY/MM/DD/`.
+4. Metadata recorded in `audit_events` (`action=export`) and `export_runs` table with checksum.
+5. Distribution email with download link sent to compliance team; link expires in 7 days.
+
+### Ad Hoc Case Packet
+1. Auditor selects case(s) within Operations Console → **Generate Audit Packet**.
+2. Backend compiles request details, attachments, communication logs, and assignment history into PDF.
+3. Auditor receives download; event logged with `action=export` and actor reference.
+4. Optional: push packet to secure document management system via webhook.
+
+### Transparency Portal Publication
+1. Weekly job sanitizes dataset (remove PII, aggregate sensitive fields).
+2. Data pushed to open-data portal (e.g., Socrata) using API token stored in secrets manager.
+3. Post-publication validation ensures row counts and schema match expectation; results stored in
+   `transparency_publication_logs` table.
+4. Notify communications team via Slack with release notes and changelog link.
+
+## Version Control Practices
+- Store automation scripts (e.g., `backup/`, `scripts/exports/`) in repository with clear README.
+- Use semantic versioning tags (e.g., `v1.2.0`) to tie operational runbooks to release snapshots.
+- Update this document whenever workflows change; cross-reference acceptance tests to maintain
+  alignment.


### PR DESCRIPTION
## Summary
- expand the README with project overview, environment setup guidance, and architecture diagrams
- add roadmap, acceptance test, and data field mapping references to anchor delivery planning
- document deployment procedures (local, VPS, Replit) and operational runbooks for staff usage, backups, and audits

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ca8917f8ec83239e53cd486e841d54