### PR TITLE
Add CI workflow and document local testing steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run migrations
+        env:
+          DJANGO_SETTINGS_MODULE: adminos_lab.settings
+        run: |
+          python manage.py migrate --noinput
+
+      - name: Run pytest
+        env:
+          DJANGO_SETTINGS_MODULE: adminos_lab.settings
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# AdminOS Lab
+
+This repository contains the AdminOS Lab Django project. The project includes a
+set of registers with accompanying tests that ensure the core functionality of
+the application remains stable.
+
+## Local development and testing
+
+Follow the steps below to mirror the checks executed in continuous integration
+and to run the test suite locally:
+
+1. **Create and activate a virtual environment** (optional but recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. **Install Python dependencies** using the provided requirements file:
+   ```bash
+   python -m pip install --upgrade pip
+   python -m pip install -r requirements.txt
+   ```
+
+3. **Apply database migrations** so the Django schema is up to date before
+   running tests:
+   ```bash
+   python manage.py migrate --noinput
+   ```
+
+4. **Run the automated test suite** with `pytest`:
+   ```bash
+   pytest
+   ```
+
+The commands above match the steps configured in the GitHub Actions workflow,
+allowing you to reproduce the CI environment locally.

--- a/adminos_lab/settings.py
+++ b/adminos_lab/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "registers",
 ]
 
 MIDDLEWARE = [

--- a/adminos_lab/urls.py
+++ b/adminos_lab/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("registers.urls")),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,7 @@ dependencies = [
 
 [tool.django]
 settings-module = "adminos_lab.settings"
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "adminos_lab.settings"
+python_files = ["tests.py", "test_*.py", "*_tests.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Django==5.2
+django-environ>=0.11
+psycopg[binary]>=3.1
+weasyprint>=61.0
+reportlab>=4.0
+pytest
+pytest-django


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies, runs migrations, and executes pytest
- create a requirements file and configure pytest so Django tests are discovered
- register the registers app URLs and update settings to keep pytest happy, plus document matching local setup instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca72866948323ae066bd2d47394e1