### PR TITLE
Configure pytest for Django project

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import os
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+django.setup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "weasyprint>=61.0",
     "reportlab>=4.0",
+    "pytest>=8.0",
+    "pytest-django>=4.8",
 ]
 
 [tool.django]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+python_files = tests.py test_*.py
+addopts = --ds=config.settings


### PR DESCRIPTION
## Summary
- add pytest and pytest-django to the project dependencies
- configure pytest to load the Django settings module and default test discovery patterns
- ensure Django initializes before the test session starts

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cca7278dd483238b5b43b4a17b20c5